### PR TITLE
Continue booting regardless if fd_mask is not cleared

### DIFF
--- a/machine/minit.c
+++ b/machine/minit.c
@@ -77,7 +77,10 @@ static void fp_init()
 #else
   uintptr_t fd_mask = (1 << ('F' - 'A')) | (1 << ('D' - 'A'));
   clear_csr(misa, fd_mask);
-  assert(!(read_csr(misa) & fd_mask));
+  if((read_csr(misa) & fd_mask))
+    {
+      printm("Failed to clear fd_mask in misa\n");
+    }
 #endif
 }
 


### PR DESCRIPTION
It seems to be harmless to boot anyway in this instance. Not sure what this check is helping with.